### PR TITLE
Feat/payment

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "migration:run": "prisma migrate deploy",
     "migration:generate": "npm run dev:load-envs prisma migrate dev",
     "lint:staged": "lint-staged",
-    "test": "jest --passWithNoTests --runInBand",
+    "test": "npm run test:load-envs jest --passWithNoTests --runInBand",
     "test:migration:run": "npm run test:load-envs prisma migrate deploy",
     "test:migration:generate": "npm run test:load-envs prisma migrate dev",
     "test:watch": "jest --watch --passWithNoTests --runInBand",

--- a/src/services/payment-service/index.ts
+++ b/src/services/payment-service/index.ts
@@ -34,7 +34,7 @@ function formatPrice(price: number) {
 async function postCreatePayment({ ticketId, stayId, userId, finalPrice }: CreatePaymentParams) {
   await checkIfTheTicketIdExists(ticketId);
 
-  await checkIfTheStayIdExists(stayId);
+  if (stayId) await checkIfTheStayIdExists(stayId);
 
   await checksIfTheUserHasAlreadyPurchased(userId);
 
@@ -54,7 +54,7 @@ function formatPaymentResponse(payment: PaymentResponse) {
 async function getPayment(userId: number) {
   const payment = await paymentRepository.findByUserId(userId);
 
-  if (!payment) return {};
+  if (!payment) return null;
 
   return formatPaymentResponse(payment);
 }


### PR DESCRIPTION
- Adicionei um comando no script "test" para fazer o Jest considerar o arquivo .env.test ao rodar os testes, ao invés do .env;
- Corrigi um bug que acontecia quando o usuário selecionava o ingresso online no front, nesse caso, o campo stayId recebido no payload da requisição é null e isso gerava um erro no banco quando ele buscava o stay pelo seu Id;
- Também modifiquei o comportamento da função getPayment, para ela retornar null, ao invés de um objeto vazio, quando o usuário ainda não tiver realizado o pagamento. Eu fiz isso para facilitar o tratamento da resposta recebida no front. 